### PR TITLE
Use host-meta lrdd to discovery the webfinger template

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ Moreover, it is nice when making/using templates to have a standard follow link 
 ## License and credits
 
 This project is inspired by [this blog post by Hugh Rundle](https://www.hughrundle.net/how-to-implement-remote-following-for-your-activitypub-project/) which documents the procedure for remote follows.
+
+## Requirements
+
+This project depends on `php-curl` and `php-xml` (SimpleXML).

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,16 +1,60 @@
 <?php
 // Define functions for getting the remote follow links
 
+/*
+    Use the host-meta file to find the activitypub lrdd template for the remote
+    instance. Return the template string if it exists, otherwise return False.
+*/
+function get_activitypub_lrdd(string $remote_instance): string|false
+{
+    // Use curl to find the host-meta file
+    $curl_session = curl_init();
+    curl_setopt($curl_session, CURLOPT_URL, "https://{$remote_instance}/.well-known/host-meta");
+    curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, true);
+
+    // Allow redirects for webfinger lookup
+    curl_setopt($curl_session, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($curl_session, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+
+    $xml_data = simplexml_load_string(curl_exec($curl_session));
+    curl_close($curl_session);
+
+    // if xml parse fails, return False
+    if (empty($xml_data)) {
+        return False;
+    }
+
+    // find the lrdd template in the xml
+    foreach ($xml_data->Link as $link) {
+        if ($link->attributes()->rel == "lrdd") {
+            return (string) $link->attributes()->template;
+        }
+    }
+
+    // if no lrdd template is found, return False
+    return False;
+}
 
 /*
     Given a remote user and instance, return an array representing the
     activitypub resource for that user if it exists, otherwise return False.
 */
-function get_activitypub_resource(string $remote_user, string $remote_instance)
+function get_activitypub_resource(string $remote_user, string $remote_instance): array
 {
+    // Get the lrdd template
+    $activitypub_lrdd = get_activitypub_lrdd($remote_instance);
+
+    if ($activitypub_lrdd === False) {
+        // if the lrdd template does not exist, use the default template
+        $resource_url = "https://{$remote_instance}/.well-known/webfinger?resource=acct:{$remote_user}@{$remote_instance}";
+    } else {
+        // if the lrdd template exists, use it to find the resource url
+        $resource_url = str_replace("{uri}", "acct:{$remote_user}@{$remote_instance}", $activitypub_lrdd);
+    }
+
     // Use curl to find the remote subscription template file
     $curl_session = curl_init();
-    curl_setopt($curl_session, CURLOPT_URL, "https://{$remote_instance}/.well-known/webfinger?resource=acct:{$remote_user}@{$remote_instance}");
+    curl_setopt($curl_session, CURLOPT_URL, $resource_url);
     curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, true);
 
     // Allow redirects for webfinger lookup
@@ -40,7 +84,7 @@ function get_activitypub_resource(string $remote_user, string $remote_instance)
     Given the output of get_activitypub_resource, return the remote follow link
     if supported by the remote server, otherwise return False.
 */
-function get_remote_follow_link(array $activitypub_resource_output, string $local_id)
+function get_remote_follow_link(array $activitypub_resource_output, string $local_id): string|false
 {
     // fail if no links in the json
     if (!array_key_exists("links", $activitypub_resource_output)) {


### PR DESCRIPTION
Closes #5 

The new behavior is to check `host-meta` and fall back to the hardcoded webfinger url only if that fails.